### PR TITLE
a "fix" for Elixir 1.15

### DIFF
--- a/lib/logger_papertrail_backend/logger.ex
+++ b/lib/logger_papertrail_backend/logger.ex
@@ -57,7 +57,8 @@ defmodule LoggerPapertrailBackend.Logger do
   defp meet_level?(_lvl, nil), do: true
 
   defp meet_level?(lvl, min) do
-    Logger.compare_levels(lvl, min) != :lt
+    level = if lvl == :warn, do: :warning, else: lvl
+    Logger.compare_levels(level, min) != :lt
   end
 
   defp configure(device, options) do


### PR DESCRIPTION
Interactive Elixir (1.15.8) - press Ctrl+C to exit (type h() ENTER for help) iex(1)> require Logger
Logger
iex(2)> Logger.warning("oops")
:ok
iex(3)> [:warn, :info]
[warning] oops
warning: the log level :warn is deprecated, use :warning instead
  (logger 1.15.8) lib/logger.ex:1140: Logger.elixir_level_to_erlang_level/1
  (logger 1.15.8) lib/logger.ex:591: Logger.compare_levels/2
  (logger_papertrail_backend 1.1.0) lib/logger_papertrail_backend/logger.ex:61: LoggerPapertrailBackend.Logger.meet_level?/2
  (logger_papertrail_backend 1.1.0) lib/logger_papertrail_backend/logger.ex:33: LoggerPapertrailBackend.Logger.handle_event/2
  (stdlib 4.3.1.6) gen_event.erl:802: :gen_event.server_update/4
  (stdlib 4.3.1.6) gen_event.erl:784: :gen_event.server_notify/4
  (stdlib 4.3.1.6) gen_event.erl:786: :gen_event.server_notify/4
  (stdlib 4.3.1.6) gen_event.erl:526: :gen_event.handle_msg/6
  (stdlib 4.3.1.6) proc_lib.erl:240: :proc_lib.init_p_do_apply/3